### PR TITLE
Support hostAliases

### DIFF
--- a/charts/csp-rancher-usage-operator/100.0.0+up0.1.0/templates/deployment.yaml
+++ b/charts/csp-rancher-usage-operator/100.0.0+up0.1.0/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
       labels:
         {{- include "csp-rancher-usage-operator.selectorLabels" . | nindent 8 }}
     spec:
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- if .Values.additionalTrustedCAs }}
       initContainers:
       - name: init-usage-operator


### PR DESCRIPTION
To enable dev testing to get around the need for a public DNS.