### PR TITLE
Check Rancher host on every interval

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,12 +52,7 @@ func run() error {
 		return err
 	}
 
-	hostname, err := k8sClients.GetRancherHostname()
-	if err != nil {
-		return fmt.Errorf("failed to start, unable to get hostname: %v", err)
-	}
-
-	m, err := manager.NewUsageOperator(k8sClients, metrics.NewScraper(hostname, cfg))
+	m, err := manager.NewUsageOperator(k8sClients, metrics.NewScraper(k8sClients, cfg))
 	if err != nil {
 		return err
 	}

--- a/pkg/clients/k8s/client.go
+++ b/pkg/clients/k8s/client.go
@@ -47,8 +47,8 @@ var (
 type Client interface {
 	// UpdateUserNotification creates/updates a RancherUserNotification based on isInCompliance and the provided message
 	UpdateUserNotification(clearError bool, message string) error
-	// GetRancherHostname finds the hostname for the core rancher install from the settings.
-	GetRancherHostname() (string, error)
+	// GetRancherMetricsAPIEndpoint finds the Rancher Metrics API endpoint.
+	GetRancherMetricsAPIEndpoint() (string, error)
 	// GetRancherVersion finds the version of rancher from the settings
 	GetRancherVersion() (string, error)
 	// UpdateProductUsage updates the RancherUsageRecord with the current managed node count
@@ -189,15 +189,13 @@ func (c *Clients) UpdateUserNotification(clearError bool, message string) error 
 	return nil
 }
 
-func (c *Clients) GetRancherHostname() (string, error) {
+func (c *Clients) GetRancherMetricsAPIEndpoint() (string, error) {
 	setting := &v3.Setting{}
 	err := c.Settings.Client().Get(context.TODO(), "", hostnameSetting, setting, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}
-	// server-url includes the protocol prefix - we need the actual hostname to be returned
-	hostname := strings.TrimPrefix(setting.Value, "https://")
-	return hostname, nil
+	return strings.Join([]string{setting.Value, "/metrics"}, ""), nil
 }
 
 func (c *Clients) GetRancherVersion() (string, error) {

--- a/pkg/metrics/scraper_test.go
+++ b/pkg/metrics/scraper_test.go
@@ -114,10 +114,19 @@ func TestScrapeAndParse(t *testing.T) {
 			if test.authed {
 				metricsServer.AddAuthToken(config.BearerToken)
 			}
+
+			merror := Error{
+				Trigger:   false,
+				Condition: "",
+			}
+
+			mockK8sClient := NewMockK8sClient(merror)
+			mockK8sClient.RancherMetricsAPIEndpoint = server.URL + "/metrics"
+
 			metricsScraper := scraper{
-				metricsURL: fmt.Sprintf("%s/metrics", server.URL),
-				cli:        &http.Client{},
-				cfg:        config,
+				k8s: mockK8sClient,
+				cli: &http.Client{},
+				cfg: config,
 			}
 			res, err := metricsScraper.ScrapeAndParse()
 			if test.expectedError {

--- a/pkg/mocks/k8sclient_mock.go
+++ b/pkg/mocks/k8sclient_mock.go
@@ -11,7 +11,7 @@ const timeFormat = time.RFC3339
 type MockK8sClient struct {
 	CurrentManagedNodeCount    int
 	CurrentNotificationMessage string
-	RancherHostName            string
+	RancherMetricsAPIEndpoint  string
 	RancherVersion             string
 
 	Error Error
@@ -36,11 +36,11 @@ func (m *MockK8sClient) UpdateUserNotification(clearError bool, message string) 
 	return nil
 }
 
-func (m *MockK8sClient) GetRancherHostname() (string, error) {
-	if m.Error.Trigger && m.Error.Condition == "ErrorRancherHostname" {
-		return "", errors.New("trigger mock error for GetRancherHostname")
+func (m *MockK8sClient) GetRancherMetricsAPIEndpoint() (string, error) {
+	if m.Error.Trigger && m.Error.Condition == "ErrorRancherMetricsAPIEndpoint" {
+		return "", errors.New("trigger mock error for GetRancherMetricsAPIEndpoint")
 	}
-	return m.RancherHostName, nil
+	return m.RancherMetricsAPIEndpoint, nil
 }
 
 func (m *MockK8sClient) GetRancherVersion() (string, error) {


### PR DESCRIPTION
Since the Rancher server-url is not immutable, we should not be getting it once at the start of the service. We should check for it at every interval so the operator is more adaptive to the server-url changes.